### PR TITLE
Update readme with mpv instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You are a captain of a nuclear submarine that is on station somewhere in the dep
 
 ## Installation
 1. Clone the repository to your machine `git clone https://github.com/Quasolaris/Hacked-for-Nuclear-War.git`
-2. Install [MPV](https://mpv.io/). This is an open source command-line media player used to play sounds in the game.
+2. Install [mpv](https://mpv.io/). This is an open source command-line media player used to play sounds in the game.
 3. *OPTIONAL* install [glow](https://github.com/charmbracelet/glow) with the package manager of your choice
 	- The script detects if you have glow installed, if not it will default to the `less` command.
 4. Run the game inside the cloned folder:


### PR DESCRIPTION
I was getting lots of `command not found: mpv` error messages. Updates the README with instructions to install [mpv](https://mpv.io/) first.

Fun note: The homepage of mpv shows a screenshot from the 1964 film [Dr. Strangelove or: How I Learned to Stop Worrying and Love the Bomb](https://en.wikipedia.org/wiki/Dr._Strangelove), a film about nuclear war.


